### PR TITLE
Ensure hems resource replenished during warmup period

### DIFF
--- a/des_hems.py
+++ b/des_hems.py
@@ -154,10 +154,12 @@ class DES_HEMS:
 
             yield self.env.timeout(30)
 
+            if patient.hems_case == 1:
+                self.hems_resources.put(hems)
+
             if not_in_warm_up_period:
                 if patient.hems_case == 1:
                     self.add_patient_result_row(patient, hems, "HEMS clear")
-                    self.hems_resources.put(hems)
                 self.add_patient_result_row(patient, ambulance, "AMB clear")
 
 


### PR DESCRIPTION
Small fix to ensure hems resources are replenished even when inside warm-up period. 

At present, if in warm-up period, hems resources are never put back into the store, so hems responses stop occurring very early in the model. No issue seen if running with 0 warm-up but causes issues when warmup > 0. 

Just a small change to order made. 