### PR TITLE
Resource use exploration part 3

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -356,7 +356,7 @@ if button_run_pressed:
             t1_col3, t1_col4 = st.columns(2)
 
         with tab2:
-            tab_2_1, tab_2_2 = st.tabs(["Resource Utilisation", "'Missed' Calls"])
+            tab_2_1, tab_2_2, tab_2_3 = st.tabs(["Resource Utilisation", "Split of Jobs by Callsign Group", "'Missed' Calls"])
             with tab_2_1:
                 @st.fragment
                 def create_utilisation_rwc_plot():
@@ -396,6 +396,20 @@ If the simulation is not using the default parameters, we would not expect the o
                 """)
 
                 with tab_2_2:
+                    @st.fragment
+                    def plot_callsign_group_split():
+                        x_is_callsign_group = st.toggle("Plot callsign group on the horizontal axis",
+                                                        value=False)
+
+                        st.plotly_chart(
+                            _utilisation_result_calculation.create_callsign_group_split_rwc_plot(
+                            x_is_callsign_group=x_is_callsign_group
+                            )
+                        )
+
+                    plot_callsign_group_split()
+
+                with tab_2_3:
                     @st.fragment
                     def missed_jobs():
                         show_proportions_per_hour = st.toggle("Show as proportion of jobs missed per hour", value=False )
@@ -629,9 +643,14 @@ Partial months are excluded for ease of interpretation.
                 def plot_days_with_job_count_hist():
                     call_df = get_job_count_df()
                     call_df["day"] = pd.to_datetime(call_df["timestamp_dt"]).dt.date
-                    daily_call_counts = call_df.groupby(['run_number', 'day'])['P_ID'].agg("count").reset_index().rename(columns={"P_ID": "Calls per Day"})
+                    daily_call_counts = (
+                        call_df.groupby(['run_number', 'day'])['P_ID'].agg("count")
+                        .reset_index().rename(columns={"P_ID": "Calls per Day"})
+                        )
 
-                    historical_daily_calls = pd.read_csv("historical_data/historical_daily_calls_breakdown.csv")
+                    historical_daily_calls = pd.read_csv(
+                        "historical_data/historical_daily_calls_breakdown.csv"
+                        )
 
                     # Create histogram with two traces
                     call_count_hist = go.Figure()

--- a/app/model.py
+++ b/app/model.py
@@ -399,9 +399,10 @@ If the simulation is not using the default parameters, we would not expect the o
                     @st.fragment
                     def missed_jobs():
                         show_proportions_per_hour = st.toggle("Show as proportion of jobs missed per hour", value=False )
-
+                        by_quarter = st.toggle("Stratify results by quarter", value=False)
                         st.plotly_chart(_job_count_calculation.plot_missed_jobs(
-                            show_proportions_per_hour=show_proportions_per_hour
+                            show_proportions_per_hour=show_proportions_per_hour,
+                            by_quarter=by_quarter
                             ))
 
                     missed_jobs()

--- a/distribution_fit_utils.py
+++ b/distribution_fit_utils.py
@@ -878,8 +878,12 @@ class DistributionFitUtils():
         df["date"] = pd.to_datetime(df["inc_date"])
         df["hour"] = df["date"].dt.hour
         df["callsign_group_simplified"] = df["callsign_group"].apply(lambda x: "No HEMS available" if x=="Other" else "HEMS (helo or car) available and sent")
-        count_df = df[["callsign_group_simplified", "hour"]].value_counts().reset_index(name="count")
-        count_df.sort_values(['callsign_group_simplified','hour']).to_csv("historical_data/historical_missed_calls_by_hour.csv", index=False)
+        count_df = df[["callsign_group_simplified", "hour"]].value_counts().reset_index(name="count").sort_values(['callsign_group_simplified','hour'])
+        count_df.to_csv("historical_data/historical_missed_calls_by_hour.csv", index=False)
+
+        df["quarter"] = df["inc_date"].dt.quarter
+        count_df_quarter = df[["callsign_group_simplified", "quarter", "hour"]].value_counts().reset_index(name="count").sort_values(['quarter','callsign_group_simplified','hour'])
+        count_df_quarter.to_csv("historical_missed_calls_by_quarter_and_hour.csv", index=False)
 
     def upper_allowable_time_bounds(self):
         """

--- a/historical_data/historical_missed_calls_by_quarter_and_hour.csv
+++ b/historical_data/historical_missed_calls_by_quarter_and_hour.csv
@@ -1,0 +1,183 @@
+callsign_group_simplified,quarter,hour,count
+HEMS (helo or car) available and sent,1,0,23
+HEMS (helo or car) available and sent,1,1,11
+HEMS (helo or car) available and sent,1,2,1
+HEMS (helo or car) available and sent,1,4,1
+HEMS (helo or car) available and sent,1,5,1
+HEMS (helo or car) available and sent,1,6,7
+HEMS (helo or car) available and sent,1,7,24
+HEMS (helo or car) available and sent,1,8,52
+HEMS (helo or car) available and sent,1,9,87
+HEMS (helo or car) available and sent,1,10,96
+HEMS (helo or car) available and sent,1,11,98
+HEMS (helo or car) available and sent,1,12,93
+HEMS (helo or car) available and sent,1,13,72
+HEMS (helo or car) available and sent,1,14,87
+HEMS (helo or car) available and sent,1,15,80
+HEMS (helo or car) available and sent,1,16,55
+HEMS (helo or car) available and sent,1,17,50
+HEMS (helo or car) available and sent,1,18,32
+HEMS (helo or car) available and sent,1,19,47
+HEMS (helo or car) available and sent,1,20,33
+HEMS (helo or car) available and sent,1,21,28
+HEMS (helo or car) available and sent,1,22,30
+HEMS (helo or car) available and sent,1,23,33
+No HEMS available,1,0,7
+No HEMS available,1,1,2
+No HEMS available,1,2,6
+No HEMS available,1,3,11
+No HEMS available,1,4,15
+No HEMS available,1,5,8
+No HEMS available,1,6,11
+No HEMS available,1,8,3
+No HEMS available,1,9,5
+No HEMS available,1,10,6
+No HEMS available,1,11,7
+No HEMS available,1,12,4
+No HEMS available,1,13,11
+No HEMS available,1,14,8
+No HEMS available,1,15,7
+No HEMS available,1,16,8
+No HEMS available,1,17,13
+No HEMS available,1,18,14
+No HEMS available,1,19,8
+No HEMS available,1,20,12
+No HEMS available,1,21,6
+No HEMS available,1,22,5
+No HEMS available,1,23,7
+HEMS (helo or car) available and sent,2,0,16
+HEMS (helo or car) available and sent,2,1,6
+HEMS (helo or car) available and sent,2,4,1
+HEMS (helo or car) available and sent,2,5,5
+HEMS (helo or car) available and sent,2,6,10
+HEMS (helo or car) available and sent,2,7,38
+HEMS (helo or car) available and sent,2,8,57
+HEMS (helo or car) available and sent,2,9,59
+HEMS (helo or car) available and sent,2,10,101
+HEMS (helo or car) available and sent,2,11,101
+HEMS (helo or car) available and sent,2,12,102
+HEMS (helo or car) available and sent,2,13,101
+HEMS (helo or car) available and sent,2,14,84
+HEMS (helo or car) available and sent,2,15,85
+HEMS (helo or car) available and sent,2,16,87
+HEMS (helo or car) available and sent,2,17,83
+HEMS (helo or car) available and sent,2,18,55
+HEMS (helo or car) available and sent,2,19,49
+HEMS (helo or car) available and sent,2,20,45
+HEMS (helo or car) available and sent,2,21,42
+HEMS (helo or car) available and sent,2,22,31
+HEMS (helo or car) available and sent,2,23,24
+No HEMS available,2,0,5
+No HEMS available,2,1,3
+No HEMS available,2,2,22
+No HEMS available,2,3,14
+No HEMS available,2,4,11
+No HEMS available,2,5,7
+No HEMS available,2,6,11
+No HEMS available,2,7,4
+No HEMS available,2,8,3
+No HEMS available,2,9,2
+No HEMS available,2,10,7
+No HEMS available,2,11,7
+No HEMS available,2,12,9
+No HEMS available,2,13,3
+No HEMS available,2,14,2
+No HEMS available,2,15,5
+No HEMS available,2,16,10
+No HEMS available,2,17,17
+No HEMS available,2,18,9
+No HEMS available,2,19,14
+No HEMS available,2,20,13
+No HEMS available,2,21,14
+No HEMS available,2,22,10
+No HEMS available,2,23,4
+HEMS (helo or car) available and sent,3,0,23
+HEMS (helo or car) available and sent,3,1,12
+HEMS (helo or car) available and sent,3,6,2
+HEMS (helo or car) available and sent,3,7,31
+HEMS (helo or car) available and sent,3,8,49
+HEMS (helo or car) available and sent,3,9,70
+HEMS (helo or car) available and sent,3,10,113
+HEMS (helo or car) available and sent,3,11,93
+HEMS (helo or car) available and sent,3,12,90
+HEMS (helo or car) available and sent,3,13,102
+HEMS (helo or car) available and sent,3,14,95
+HEMS (helo or car) available and sent,3,15,124
+HEMS (helo or car) available and sent,3,16,81
+HEMS (helo or car) available and sent,3,17,73
+HEMS (helo or car) available and sent,3,18,63
+HEMS (helo or car) available and sent,3,19,53
+HEMS (helo or car) available and sent,3,20,48
+HEMS (helo or car) available and sent,3,21,27
+HEMS (helo or car) available and sent,3,22,36
+HEMS (helo or car) available and sent,3,23,29
+No HEMS available,3,0,3
+No HEMS available,3,1,4
+No HEMS available,3,2,16
+No HEMS available,3,3,16
+No HEMS available,3,4,6
+No HEMS available,3,5,14
+No HEMS available,3,6,4
+No HEMS available,3,7,4
+No HEMS available,3,8,4
+No HEMS available,3,9,1
+No HEMS available,3,10,5
+No HEMS available,3,11,6
+No HEMS available,3,12,6
+No HEMS available,3,13,10
+No HEMS available,3,14,9
+No HEMS available,3,15,9
+No HEMS available,3,16,5
+No HEMS available,3,17,8
+No HEMS available,3,18,15
+No HEMS available,3,19,12
+No HEMS available,3,20,13
+No HEMS available,3,21,8
+No HEMS available,3,22,8
+No HEMS available,3,23,5
+HEMS (helo or car) available and sent,4,0,14
+HEMS (helo or car) available and sent,4,1,12
+HEMS (helo or car) available and sent,4,2,1
+HEMS (helo or car) available and sent,4,5,1
+HEMS (helo or car) available and sent,4,6,3
+HEMS (helo or car) available and sent,4,7,28
+HEMS (helo or car) available and sent,4,8,61
+HEMS (helo or car) available and sent,4,9,70
+HEMS (helo or car) available and sent,4,10,69
+HEMS (helo or car) available and sent,4,11,89
+HEMS (helo or car) available and sent,4,12,82
+HEMS (helo or car) available and sent,4,13,78
+HEMS (helo or car) available and sent,4,14,81
+HEMS (helo or car) available and sent,4,15,70
+HEMS (helo or car) available and sent,4,16,57
+HEMS (helo or car) available and sent,4,17,46
+HEMS (helo or car) available and sent,4,18,54
+HEMS (helo or car) available and sent,4,19,40
+HEMS (helo or car) available and sent,4,20,45
+HEMS (helo or car) available and sent,4,21,26
+HEMS (helo or car) available and sent,4,22,33
+HEMS (helo or car) available and sent,4,23,27
+No HEMS available,4,0,3
+No HEMS available,4,1,4
+No HEMS available,4,2,21
+No HEMS available,4,3,16
+No HEMS available,4,4,13
+No HEMS available,4,5,21
+No HEMS available,4,6,8
+No HEMS available,4,7,2
+No HEMS available,4,8,4
+No HEMS available,4,9,11
+No HEMS available,4,10,7
+No HEMS available,4,11,5
+No HEMS available,4,12,8
+No HEMS available,4,13,10
+No HEMS available,4,14,14
+No HEMS available,4,15,4
+No HEMS available,4,16,4
+No HEMS available,4,17,8
+No HEMS available,4,18,12
+No HEMS available,4,19,6
+No HEMS available,4,20,13
+No HEMS available,4,21,8
+No HEMS available,4,22,8
+No HEMS available,4,23,3


### PR DESCRIPTION
- Add option to stratify missed calls by quarter
![image](https://github.com/user-attachments/assets/4e07043a-7d2a-41af-b0e1-4f402d5c1e89)

![image](https://github.com/user-attachments/assets/799d4ab6-f2ec-4d13-adb0-14c9a1eb7ac7)

- Add new plot in 'key visualisations' that breaks down the allocation of calls to different callsign groups
![image](https://github.com/user-attachments/assets/26ea77df-a095-44c1-a911-4fa2fb2c19e3)

![image](https://github.com/user-attachments/assets/3085523f-e74c-436b-9698-875a952b1f40)
