### PR TITLE
Ec cc viz

### DIFF
--- a/app/_state_control.py
+++ b/app/_state_control.py
@@ -28,7 +28,8 @@ DEFAULT_INPUTS = {
     "scenario_2_set": False,
     "rota_initialised": False,
     # "activity_duration_multiplier": 1.0
-    "activity_duration_multiplier": 1.0
+    "activity_duration_multiplier": 1.0,
+    "master_seed": 42
 }
 
 # Adjust some parameters depending on whether it is running

--- a/app/model.py
+++ b/app/model.py
@@ -140,7 +140,8 @@ if button_run_pressed:
                         amb_data=st.session_state.amb_data,
                         demand_increase_percent=float(st.session_state.overall_demand_mult)/100.0,
                         activity_duration_multiplier=float(st.session_state.activity_duration_multiplier),
-                        print_debug_messages=debug_messages
+                        print_debug_messages=debug_messages,
+                        master_seed=st.session_state.master_seed
                     )
 
                 results.append(
@@ -170,7 +171,8 @@ if button_run_pressed:
                         amb_data = st.session_state.amb_data,
                         demand_increase_percent=float(st.session_state.overall_demand_mult)/100.0,
                         activity_duration_multiplier=float(st.session_state.activity_duration_multiplier),
-                        print_debug_messages=debug_messages
+                        print_debug_messages=debug_messages,
+                        master_seed=st.session_state.master_seed
 
             )
             collateRunResults()

--- a/app/model.py
+++ b/app/model.py
@@ -358,8 +358,50 @@ if button_run_pressed:
             t1_col3, t1_col4 = st.columns(2)
 
         with tab2:
-            tab_2_1, tab_2_2, tab_2_3 = st.tabs(["Resource Utilisation", "Split of Jobs by Callsign Group", "'Missed' Calls"])
+            tab_2_1, tab_2_2, tab_2_3 = st.tabs(["'Missed' Calls", "Resource Utilisation", "Split of Jobs by Callsign Group"])
+
             with tab_2_1:
+                @st.fragment
+                def missed_jobs():
+                    show_proportions_per_hour = st.toggle("Show as proportion of jobs missed per hour", value=False )
+                    by_quarter = st.toggle("Stratify results by quarter", value=False)
+                    st.plotly_chart(_job_count_calculation.plot_missed_jobs(
+                        show_proportions_per_hour=show_proportions_per_hour,
+                        by_quarter=by_quarter
+                        ))
+
+                missed_jobs()
+
+                st.caption("""
+## What is this plot showing?
+
+This chart shows how often helicopter emergency medical services (HEMS) were either available and sent or unavailable during each hour of the day. It compares simulated data (used for testing or planning purposes) with historical data (what actually happened in the past).
+
+- The top chart shows the simulated job counts by hour.
+
+- The bottom chart shows the historical job counts by hour.
+
+## What do the colours mean?
+
+Each bar is split into:
+
+- Dark blue: When a HEMS vehicle (either helicopter or car) was available and sent to a job.
+
+- Light blue: When no HEMS was available for a job received during that time period.
+
+If more of the bar is light blue, this means that there were more jobs in that hour that were not responded to by a HEMS resource due to no HEMS resource being available at the time.
+
+## Using this plot for model quality assurance
+
+If the default historical parameters are being used, this plot can be used to judge if the simulation is mirroring reality well.
+In this case, we would be looking for two things to be consistent across the top and bottom plots:
+
+- the overall pattern of bar heights per hour (reflecting the total number of jobs being received each hour)
+- the split between dark and light blue per hour (reflecting how often a resource is or is not available to respond to a job received in that hour)
+
+""")
+
+            with tab_2_2:
                 @st.fragment
                 def create_utilisation_rwc_plot():
                     call_df = get_job_count_df()
@@ -397,7 +439,7 @@ If the simulation is not using the default parameters, we would not expect the o
     wish to consider the historical split as part of your decision making.
                 """)
 
-                with tab_2_2:
+                with tab_2_3:
                     @st.fragment
                     def plot_callsign_group_split():
                         x_is_callsign_group = st.toggle("Plot callsign group on the horizontal axis",
@@ -411,46 +453,6 @@ If the simulation is not using the default parameters, we would not expect the o
 
                     plot_callsign_group_split()
 
-                with tab_2_3:
-                    @st.fragment
-                    def missed_jobs():
-                        show_proportions_per_hour = st.toggle("Show as proportion of jobs missed per hour", value=False )
-                        by_quarter = st.toggle("Stratify results by quarter", value=False)
-                        st.plotly_chart(_job_count_calculation.plot_missed_jobs(
-                            show_proportions_per_hour=show_proportions_per_hour,
-                            by_quarter=by_quarter
-                            ))
-
-                    missed_jobs()
-
-                    st.caption("""
-## What is this plot showing?
-
-This chart shows how often helicopter emergency medical services (HEMS) were either available and sent or unavailable during each hour of the day. It compares simulated data (used for testing or planning purposes) with historical data (what actually happened in the past).
-
-- The top chart shows the simulated job counts by hour.
-
-- The bottom chart shows the historical job counts by hour.
-
-## What do the colours mean?
-
-Each bar is split into:
-
-- Dark blue: When a HEMS vehicle (either helicopter or car) was available and sent to a job.
-
-- Light blue: When no HEMS was available for a job received during that time period.
-
-If more of the bar is light blue, this means that there were more jobs in that hour that were not responded to by a HEMS resource due to no HEMS resource being available at the time.
-
-## Using this plot for model quality assurance
-
-If the default historical parameters are being used, this plot can be used to judge if the simulation is mirroring reality well.
-In this case, we would be looking for two things to be consistent across the top and bottom plots:
-
-- the overall pattern of bar heights per hour (reflecting the total number of jobs being received each hour)
-- the split between dark and light blue per hour (reflecting how often a resource is or is not available to respond to a job received in that hour)
-
-""")
 
 
         with tab3:

--- a/app/model.py
+++ b/app/model.py
@@ -1164,7 +1164,14 @@ the overall time period.*
 
             st.subheader("Jobs Outcome by Category/Preference")
 
-            st.plotly_chart(_job_outcome_calculation.get_preferred_outcome_by_hour())
+            @st.fragment
+            def plot_preferred_outcome_by_hour():
+                show_proportions_job_outcomes_by_hour = st.toggle("Show Proportions", False, key="show_proportions_job_outcomes_by_hour")
+                st.plotly_chart(_job_outcome_calculation.get_preferred_outcome_by_hour(show_proportions=show_proportions_job_outcomes_by_hour))
+
+            plot_preferred_outcome_by_hour()
+
+            st.plotly_chart(_job_outcome_calculation.get_facet_plot_preferred_outcome_by_hour())
 
             with tab_4_2:
                 st.subheader("Event Overview")

--- a/app/model.py
+++ b/app/model.py
@@ -48,6 +48,7 @@ import visualisation._vehicle_calculation as _vehicle_calculation
 import visualisation._utilisation_result_calculation as _utilisation_result_calculation
 import visualisation._job_time_calcs as _job_time_calcs
 import visualisation._process_analytics as _process_analytics
+import visualisation._job_outcome_calculation as _job_outcome_calculation
 
 setup_state()
 
@@ -362,7 +363,7 @@ if button_run_pressed:
             t1_col3, t1_col4 = st.columns(2)
 
         with tab2:
-            tab_2_1, tab_2_2, tab_2_3 = st.tabs(["'Missed' Calls", "Resource Utilisation", "Split of Jobs by Callsign Group"])
+            tab_2_1, tab_2_2, tab_2_3, tab_2_4 = st.tabs(["'Missed' Calls", "Resource Utilisation", "Split of Jobs by Callsign Group", "CC and EC Benefit"])
 
             with tab_2_1:
                 @st.fragment
@@ -456,6 +457,20 @@ If the simulation is not using the default parameters, we would not expect the o
                         )
 
                     plot_callsign_group_split()
+
+                with tab_2_4:
+
+                    @st.fragment
+                    def plot_cc_ec_split():
+                        show_proportions_care_cat_plot = st.toggle("Show Proportions", False)
+
+                        st.plotly_chart(
+                            _job_outcome_calculation.get_care_cat_counts(
+                                show_proportions=show_proportions_care_cat_plot
+                                )
+                        )
+
+                    plot_cc_ec_split()
 
 
 
@@ -1146,6 +1161,10 @@ the overall time period.*
                 st.plotly_chart(
                     px.bar(daily_availability_df, x="month", y="theoretical_availability", facet_row="callsign")
                 )
+
+            st.subheader("Jobs Outcome by Category/Preference")
+
+            st.plotly_chart(_job_outcome_calculation.get_preferred_outcome_by_hour())
 
             with tab_4_2:
                 st.subheader("Event Overview")

--- a/app/model.py
+++ b/app/model.py
@@ -77,8 +77,12 @@ with col2:
     st.image("app/assets/daa-logo.svg", width=200)
 
 with st.sidebar:
+    generate_downloadable_report = st.toggle("Generate a Downloadable Summary of Results", False,
+                                             help="This will generate a downloadable report. This can slow down the running of the model, so turn this off if you don't need it.")
+
     debug_messages = st.toggle("Turn on debugging messages", False,
                                help="This will turn on display of messages in the developer terminal")
+
     _app_utils.summary_sidebar(quarto_string=quarto_string)
 
 with stylable_container(key="run_buttons",
@@ -1347,17 +1351,18 @@ the overall time period.*
 
 
         with tab5:
-            try:
-                with open("app/fig_outputs/quarto_text.txt", "w") as text_file:
-                    text_file.write(quarto_string)
+            if generate_downloadable_report:
+                try:
+                    with open("app/fig_outputs/quarto_text.txt", "w") as text_file:
+                        text_file.write(quarto_string)
 
-                msg = _app_utils.generate_quarto_report(run_quarto_check=False)
+                    msg = _app_utils.generate_quarto_report(run_quarto_check=False)
 
-                # print(msg)
+                    # print(msg)
 
-                if msg == "success":
-                    report_message.success("Report Available for Download")
+                    if msg == "success":
+                        report_message.success("Report Available for Download")
 
-            except:
-                ## error message
-                report_message.error(f"Report cannot be generated - please speak to a developer")
+                except:
+                    ## error message
+                    report_message.error(f"Report cannot be generated - please speak to a developer")

--- a/app/setup.py
+++ b/app/setup.py
@@ -590,6 +590,12 @@ as well as the demand (average number of jobs received).
         key="key_sim_start_time_input"
         ).strftime("%H:%M")
 
+    st.markdown("### Reproducibility and Variation")
+
+    master_seed = st.number_input("Set the master random seed", 1, 100000, 42,
+                                  key="key_master_seed",
+                                  on_change=lambda: setattr(st.session_state, 'master_seed', st.session_state.key_master_seed))
+
     st.markdown("### Other Modifiers")
 
     activity_duration_multiplier = st.slider(

--- a/visualisation/_job_outcome_calculation.py
+++ b/visualisation/_job_outcome_calculation.py
@@ -7,3 +7,39 @@ results.
 
 Covers variation within the simulation, and comparison with real world data.
 """
+
+
+import pandas as pd
+import plotly.express as px
+
+def get_care_cat_counts(results_path="data/run_results.csv",
+                        show_proportions=False):
+    run_results = pd.read_csv(results_path)
+
+    care_cat_by_hour = run_results[run_results["time_type"]=="arrival"][["P_ID", "run_number", "care_cat", "hour"]].reset_index().groupby(["hour", "care_cat"]).size().reset_index(name="count")
+    # Calculate total per hour
+    total_per_hour = care_cat_by_hour.groupby("hour")["count"].transform("sum")
+    # Add proportion column
+    care_cat_by_hour["proportion"] = care_cat_by_hour["count"] / total_per_hour
+
+    if not show_proportions:
+        fig = px.bar(care_cat_by_hour, x="hour", y="count", color="care_cat")
+        return fig
+
+    # if show_proportions
+    else:
+        fig = px.bar(care_cat_by_hour, x="hour", y="proportion", color="care_cat")
+        return fig
+
+
+def get_preferred_outcome_by_hour(results_path="data/run_results.csv"):
+    run_results = pd.read_csv(results_path)
+    resource_preferred_outcome_by_hour = run_results[run_results["event_type"]=="resource_preferred_outcome"][["P_ID", "run_number", "care_cat", "time_type", "hour"]].reset_index().groupby(["time_type", "hour"]).size().reset_index(name="count")
+    # Calculate total per hour
+    total_per_hour = resource_preferred_outcome_by_hour.groupby("hour")["count"].transform("sum")
+    # Add proportion column
+    resource_preferred_outcome_by_hour["proportion"] = resource_preferred_outcome_by_hour["count"] / total_per_hour
+
+    fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="count", color="time_type")
+
+    return fig

--- a/visualisation/_job_outcome_calculation.py
+++ b/visualisation/_job_outcome_calculation.py
@@ -11,6 +11,8 @@ Covers variation within the simulation, and comparison with real world data.
 
 import pandas as pd
 import plotly.express as px
+import textwrap
+
 
 def get_care_cat_counts(results_path="data/run_results.csv",
                         show_proportions=False):
@@ -32,7 +34,7 @@ def get_care_cat_counts(results_path="data/run_results.csv",
         return fig
 
 
-def get_preferred_outcome_by_hour(results_path="data/run_results.csv"):
+def get_preferred_outcome_by_hour(results_path="data/run_results.csv", show_proportions=False):
     run_results = pd.read_csv(results_path)
     resource_preferred_outcome_by_hour = run_results[run_results["event_type"]=="resource_preferred_outcome"][["P_ID", "run_number", "care_cat", "time_type", "hour"]].reset_index().groupby(["time_type", "hour"]).size().reset_index(name="count")
     # Calculate total per hour
@@ -40,6 +42,27 @@ def get_preferred_outcome_by_hour(results_path="data/run_results.csv"):
     # Add proportion column
     resource_preferred_outcome_by_hour["proportion"] = resource_preferred_outcome_by_hour["count"] / total_per_hour
 
-    fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="count", color="time_type")
+    if not show_proportions:
+        fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="count", color="time_type")
+
+    else:
+        fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="proportion", color="time_type")
+
+    return fig
+
+
+def get_facet_plot_preferred_outcome_by_hour(results_path="data/run_results.csv"):
+    run_results = pd.read_csv(results_path)
+    resource_preferred_outcome_by_hour = run_results[run_results["event_type"]=="resource_preferred_outcome"][["P_ID", "run_number", "care_cat", "time_type", "hour"]].reset_index().groupby(["time_type", "hour"]).size().reset_index(name="count")
+    # Calculate total per hour
+    total_per_hour = resource_preferred_outcome_by_hour.groupby("hour")["count"].transform("sum")
+    # Add proportion column
+    resource_preferred_outcome_by_hour["proportion"] = resource_preferred_outcome_by_hour["count"] / total_per_hour
+
+    resource_preferred_outcome_by_hour["time_type"] = resource_preferred_outcome_by_hour["time_type"].apply(
+    lambda x: textwrap.fill(x, width=25).replace("\n", "<br>")
+)
+
+    fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="proportion", facet_col="time_type", facet_col_wrap=4, height=800, facet_col_spacing=0.05, facet_row_spacing=0.1)
 
     return fig

--- a/visualisation/_job_outcome_calculation.py
+++ b/visualisation/_job_outcome_calculation.py
@@ -63,6 +63,7 @@ def get_facet_plot_preferred_outcome_by_hour(results_path="data/run_results.csv"
     lambda x: textwrap.fill(x, width=25).replace("\n", "<br>")
 )
 
-    fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="proportion", facet_col="time_type", facet_col_wrap=4, height=800, facet_col_spacing=0.05, facet_row_spacing=0.1)
+    fig = px.bar(resource_preferred_outcome_by_hour, x="hour", y="proportion", facet_col="time_type",
+                 facet_col_wrap=4, height=800, facet_col_spacing=0.05, facet_row_spacing=0.13)
 
     return fig


### PR DESCRIPTION
A couple of extra viz

Under additional outputs --> debug resources, at bottom of page

![image](https://github.com/user-attachments/assets/bc4970bb-a76d-46e4-8ae3-94827d442411)

![image](https://github.com/user-attachments/assets/9ee7ed49-e3ae-40eb-8f7c-ff7d33795cc4)


![image](https://github.com/user-attachments/assets/939794e7-c91c-4c80-8fbb-ccf3ef0d07c2)

Also cc and ec stuff beginning to be added to key visualisations tab, though no historical comparisons in there yet

![image](https://github.com/user-attachments/assets/6eded772-38a5-44ad-a4ef-6928d1052b6c)

![image](https://github.com/user-attachments/assets/a20090b2-60ae-43d9-ab5d-e5e3eeb709a1)



Also makes quarto output optional and off by default for now (speeds up testing via web app interface)

And it's now possible to change the master seed via the web app interface (choose model parameters page)

I've added cc/ec/reg info when hovering over the resource use barplot, but due to the way that's set up, it's not easy for me to make it any more obvious via colour etc