### PR TITLE
Interface rota rewrite

### DIFF
--- a/actual_data/rota_start_end_months.csv
+++ b/actual_data/rota_start_end_months.csv
@@ -1,0 +1,3 @@
+what,month
+summer_start_month,4
+summer_end_month,10

--- a/app/_state_control.py
+++ b/app/_state_control.py
@@ -77,8 +77,16 @@ def setup_state():
 def reset_to_defaults():
     for session_state_key, session_state_default_value in DEFAULT_INPUTS.items():
             st.session_state[session_state_key] = session_state_default_value
+
+    callsign_registration_lookup = pd.read_csv("actual_data/callsign_registration_lookup_DEFAULT.csv")
+    callsign_registration_lookup.to_csv("actual_data/callsign_registration_lookup.csv", index=False)
+
+    models = pd.read_csv("actual_data/service_schedules_by_model_DEFAULT.csv")
+    models.to_csv("actual_data/service_schedules_by_model.csv", index=False)
+
     base_rota = pd.read_csv("actual_data/HEMS_ROTA_DEFAULT.csv")
     base_rota.to_csv("actual_data/HEMS_ROTA.csv", index=False)
+
     st.toast("All parameters have been reset to the default values",
              icon=":material/history:")
 

--- a/app/_state_control.py
+++ b/app/_state_control.py
@@ -30,7 +30,9 @@ DEFAULT_INPUTS = {
     # "activity_duration_multiplier": 1.0
     "activity_duration_multiplier": 1.0,
     "master_seed": 42,
-    "debugging_messages_to_log": False
+    "debugging_messages_to_log": False,
+    "summer_start_month_index": 3,
+    "summer_end_month_index": 9
 }
 
 # Adjust some parameters depending on whether it is running

--- a/app/model.py
+++ b/app/model.py
@@ -334,20 +334,20 @@ if button_run_pressed:
 
                 def format_diff(value):
                     if value > 0:
-                        return f":red[+{value:.0f}]"
+                        return f"**:red[+{value:.0f}]** from historical"
                     elif value < 0:
-                        return f":green[{value:.0f}]"
+                        return f"**:green[{value:.0f}]** from historical"
                     else:
-                        return
+                        return "**:gray[no difference]** from historical"
                 # '''''''''''''''''''''''''''''''''''''''''''''''''' #
 
                 missed_jobs_sim_string = f"""
     The simulation estimates that, with the proposed conditions, there would be - on average, per year - roughly
 
-    - **{sim_missed_cc:.0f} critical care** jobs that would be missed due to no resource being available  (*{format_diff(diff_missed_cc)} from historical*)
-    - **{sim_missed_ec:.0f} enhanced care** jobs that would be missed due to no resource being available (*{format_diff(diff_missed_ec)} from historical*)
-    - **{sim_missed_all_reg:.0f} jobs with no predicted CC or EC intervention** that would be missed due to no resource being available (*{format_diff(diff_missed_all_reg)} from historical*)
-        - of these missed regular jobs, **{sim_missed_reg_heli_benefit:.0f}** may have benefitted from the attendance of a helicopter (*{format_diff(diff_missed_reg_heli_benefit)} from historical*)
+    - **{sim_missed_cc:.0f} critical care** jobs that would be missed due to no resource being available  (*{format_diff(diff_missed_cc)}*)
+    - **{sim_missed_ec:.0f} enhanced care** jobs that would be missed due to no resource being available (*{format_diff(diff_missed_ec)}*)
+    - **{sim_missed_all_reg:.0f} jobs with no predicted CC or EC intervention** that would be missed due to no resource being available (*{format_diff(diff_missed_all_reg)}*)
+        - of these missed regular jobs, **{sim_missed_reg_heli_benefit:.0f}** may have benefitted from the attendance of a helicopter (*{format_diff(diff_missed_reg_heli_benefit)}*)
                             """
 
                 st.write(missed_jobs_sim_string)

--- a/app/setup.py
+++ b/app/setup.py
@@ -128,7 +128,8 @@ def fleet_setup():
 
     updated_helos_df = st.data_editor(
         default_helos,
-        hide_index=True
+        hide_index=True,
+        key="helicopter_data_editor"
         )
 
     st.markdown("#### Define the Backup Cars")
@@ -140,7 +141,8 @@ def fleet_setup():
 
     updated_backup_cars_df = st.data_editor(
         backup_cars,
-        hide_index=True
+        hide_index=True,
+        key="backup_car_data_editor"
     )
 
     st.markdown("### Define the Cars")
@@ -148,7 +150,8 @@ def fleet_setup():
 
     updated_cars_df = st.data_editor(
         default_cars,
-        hide_index=True
+        hide_index=True,
+        key="standalone_car_data_editor"
         )
 
     final_df = pd.concat([updated_helos_df, updated_backup_cars_df, updated_cars_df])

--- a/app/setup.py
+++ b/app/setup.py
@@ -156,8 +156,9 @@ def fleet_setup():
 
     final_df = pd.concat([updated_helos_df, updated_backup_cars_df, updated_cars_df])
 
-    final_df[callsign_lookup_columns].to_csv("actual_data/callsign_registration_lookup.csv", index=False)
-    final_df[models_columns].to_csv("actual_data/service_schedules_by_model.csv", index=False)
+    final_df[callsign_lookup_columns].drop_duplicates().to_csv("actual_data/callsign_registration_lookup.csv", index=False)
+
+    final_df[models_columns].drop_duplicates().to_csv("actual_data/service_schedules_by_model.csv", index=False)
 
     # hems_rota_default['callsign_group'] = hems_rota_default['callsign_group'].astype('str')
     hems_rota = hems_rota_default[hems_rota_default["callsign"].isin(final_df.callsign.unique())]

--- a/app/setup.py
+++ b/app/setup.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 from datetime import time, datetime
 import calendar
 # Workaround to deal with relative import issues
@@ -175,7 +176,7 @@ updated_helos_df, updated_cars_df  = fleet_setup()
 # print("Car")
 # print(default_cars)
 
-st.markdown("#### Set the Fleet Rota Details")
+st.header("HEMS Rota Builder")
 
 @st.fragment
 def rota_start_end_dates():
@@ -261,102 +262,180 @@ rota_start_end_dates()
 
 @st.fragment()
 def rota_setup():
-    # Load the default callsigns
+    # Load callsign registration
     callsign_registration_lookup_df = pd.read_csv("actual_data/callsign_registration_lookup.csv")
+    callsign_registration_lookup_df["callsign_group"] = callsign_registration_lookup_df["callsign"].str.extract(r"(\d+)")
+    callsign_registration_lookup_df["vehicle_type"] = callsign_registration_lookup_df["model"].apply(
+        lambda x: "helicopter" if "Airbus" in x else "car"
+    )
 
-    # Load default rota config
+    # Load default rota
     try:
         df_default_rota = pd.read_csv("actual_data/HEMS_ROTA_DEFAULT.csv")
     except FileNotFoundError:
         st.error("HEMS_ROTA_DEFAULT.csv not found!")
         st.stop()
 
-    st.title("HEMS Rota Builder")
+    # Sort: group, then helicopter first
+    vehicle_order = CategoricalDtype(categories=["helicopter", "car"], ordered=True)
+    callsign_registration_lookup_df["vehicle_type"] = callsign_registration_lookup_df["vehicle_type"].astype(vehicle_order)
+    sorted_lookup_df = callsign_registration_lookup_df.sort_values(by=["callsign_group", "vehicle_type"])
 
     rota_data = {}
+    helicopter_rotas_by_group = {}
 
-    for idx, row in callsign_registration_lookup_df.iterrows():
+    for idx, row in sorted_lookup_df.iterrows():
         callsign = row['callsign']
         model = row['model']
+        vehicle_type = row['vehicle_type']
+        group = row['callsign_group']
 
-        st.subheader(f"Set up rota for {callsign} ({model})")
+        st.markdown(f"#### Set up rota for {callsign} ({model})")
 
-        # Try to load existing config rows for this callsign
         existing_rota = df_default_rota[df_default_rota["callsign"] == callsign].copy()
 
         if not existing_rota.empty:
             num_rows = len(existing_rota)
         else:
             num_rows = st.number_input(f"Number of shifts for {callsign}", min_value=1, max_value=5, value=2, key=f"{callsign}_num_rows")
-
-            # Determine default category
-            default_category = "EC" if "Airbus" in model else "CC"
-
+            default_category = "EC" if vehicle_type == "helicopter" else "CC"
             existing_rota = pd.DataFrame({
                 "callsign": [callsign]*num_rows,
                 "category": [default_category]*num_rows,
-                "vehicle_type": ["helicopter" if "Airbus" in model else "car"]*num_rows,
-                "callsign_group": [callsign[-2:]]*num_rows,
+                "vehicle_type": [vehicle_type]*num_rows,
+                "callsign_group": [group]*num_rows,
                 "summer_start": [7]*num_rows,
                 "winter_start": [7]*num_rows,
                 "summer_end": [19]*num_rows,
                 "winter_end": [19]*num_rows,
             })
 
-        # Data editor
-        edited_df = st.data_editor(
-            existing_rota.set_index('callsign'),
-            column_order=["category", "summer_start", "summer_end", "winter_start", "winter_end"],
-            column_config={
-                "category": st.column_config.SelectboxColumn(
-                    label="Category",
-                    options=["CC", "EC"],
-                    required=True
-                ),
-                "summer_start": st.column_config.NumberColumn(
-                    label="Summer Start Hour",
-                    min_value=0,
-                    max_value=23,
-                    step=1,
-                    required=True
-                ),
-                "summer_end": st.column_config.NumberColumn(
-                    label="Summer End Hour",
-                    min_value=0,
-                    max_value=23,
-                    step=1,
-                    required=True
-                ),
-                "winter_start": st.column_config.NumberColumn(
-                    label="Winter Start Hour",
-                    min_value=0,
-                    max_value=23,
-                    step=1,
-                    required=True
-                ),
-                "winter_end": st.column_config.NumberColumn(
-                    label="Winter End Hour",
-                    min_value=0,
-                    max_value=23,
-                    step=1,
-                    required=True
+        if vehicle_type == "car" and group in helicopter_rotas_by_group:
+            toggle_key = f"{callsign}_same_as_heli"
+            overwrite_key = f"{callsign}_overwrite_heli_rota"
+            prev_toggle_key = f"{toggle_key}_prev"
+
+            # Initialize session state keys
+            if prev_toggle_key not in st.session_state:
+                st.session_state[prev_toggle_key] = True # Default: try to use heli rota
+            if toggle_key not in st.session_state:
+                 # Initialize toggle state based on prev_toggle_key's default or existing value
+                st.session_state[toggle_key] = st.session_state[prev_toggle_key]
+            if overwrite_key not in st.session_state:
+                st.session_state[overwrite_key] = False
+                # If starting in sync mode, flag initial overwrite
+                if st.session_state[toggle_key]:
+                     st.session_state[overwrite_key] = True
+
+
+            # Get the toggle state from *before* this script run's interaction for change detection
+            previous_run_toggle_value = st.session_state[prev_toggle_key]
+
+            # Toggle widget. Its state is stored in st.session_state[toggle_key].
+            # The `value` parameter is mainly for the first render if key is not in session_state.
+            # For subsequent renders, the widget uses the value from st.session_state[toggle_key].
+            use_heli_rota = st.toggle(
+                f"Use same rota as helicopter for group {group}?",
+                key=toggle_key # Streamlit manages state via this key
+            )
+
+            # Detect change from False (custom) to True (sync with heli)
+            if use_heli_rota and not previous_run_toggle_value:
+                st.session_state[overwrite_key] = True  # Flag to overwrite rota with helicopter's
+
+            # Update prev_toggle_key for the next script run
+            st.session_state[prev_toggle_key] = use_heli_rota
+
+            if use_heli_rota:
+                # If using helicopter rota, always fetch a fresh copy.
+                # The overwrite_key helps manage the transition message or specific one-time actions if needed.
+                edited_df = helicopter_rotas_by_group[group].copy()
+                edited_df["callsign"] = callsign
+                edited_df["vehicle_type"] = "car"
+
+                if st.session_state[overwrite_key]:
+                    # If an overwrite was specifically flagged (transition from custom to heli),
+                    # you could add specific actions here. Then reset the flag.
+                    st.session_state[overwrite_key] = False
+
+                st.info(f"Using helicopter rota for {callsign}.")
+            else:
+                # Custom rota for the car
+                edited_df = st.data_editor(
+                    existing_rota.set_index('callsign'),
+                    column_order=["category", "summer_start", "summer_end", "winter_start", "winter_end"],
+                    column_config={
+                        "category": st.column_config.SelectboxColumn(label="Category", options=["CC", "EC"], required=True),
+                        "summer_start": st.column_config.NumberColumn(label="Summer Start Hour", min_value=0, max_value=23, step=1, required=True),
+                        "summer_end": st.column_config.NumberColumn(label="Summer End Hour", min_value=0, max_value=23, step=1, required=True),
+                        "winter_start": st.column_config.NumberColumn(label="Winter Start Hour", min_value=0, max_value=23, step=1, required=True),
+                        "winter_end": st.column_config.NumberColumn(label="Winter End Hour", min_value=0, max_value=23, step=1, required=True)
+                    },
+                    hide_index=True,
+                    num_rows="dynamic",
+                    key=f"{callsign}_editor"
                 )
-            },
-            hide_index=True,
-            num_rows="dynamic",
-            key=f"{callsign}_editor"
-        )
+        else:
+            # Default editor for helicopters or cars not in a group with a processed helicopter
+            edited_df = st.data_editor(
+                existing_rota.set_index('callsign'),
+                column_order=["category", "summer_start", "summer_end", "winter_start", "winter_end"],
+                column_config={
+                    "category": st.column_config.SelectboxColumn(label="Category", options=["CC", "EC"], required=True),
+                    "summer_start": st.column_config.NumberColumn(label="Summer Start Hour", min_value=0, max_value=23, step=1, required=True),
+                    "summer_end": st.column_config.NumberColumn(label="Summer End Hour", min_value=0, max_value=23, step=1, required=True),
+                    "winter_start": st.column_config.NumberColumn(label="Winter Start Hour", min_value=0, max_value=23, step=1, required=True),
+                    "winter_end": st.column_config.NumberColumn(label="Winter End Hour", min_value=0, max_value=23, step=1, required=True)
+                },
+                hide_index=True,
+                num_rows="dynamic",
+                key=f"{callsign}_editor"
+            )
 
         rota_data[callsign] = edited_df.reset_index(drop=False)
 
-    # Preview of full rota
+        if vehicle_type == "helicopter":
+            # Ensure the helicopter_rotas_by_group stores the DataFrame with the 'callsign' column,
+            # even if it's temporarily set as index in data_editor.
+            # We need a clean copy without 'callsign' as index for later .copy() operations.
+            helicopter_rotas_by_group[group] = edited_df.reset_index(drop=True)
+
+
     st.markdown("## Full Rota Preview")
     full_rota_df = pd.concat(rota_data.values(), ignore_index=True)
-    full_rota_df["callsign_group"] = full_rota_df["callsign"].str.extract(r"(\d+)")
+
+    # Reconstruct 'callsign_group' and 'vehicle_type' for consistent final DataFrame structure if needed
+    # This depends on whether df_default_rota.columns includes these explicitly or if they are derived.
+    # Assuming df_default_rota.columns is the source of truth for final columns:
+    # Add missing columns that are expected in df_default_rota if not present in full_rota_df
+    # For example, if 'callsign_group' and 'vehicle_type' are critical for the output CSV based on df_default_rota schema:
+
+    # Ensure 'callsign_group' is present (it was extracted from callsign_registration_lookup_df earlier)
+    # We need to map it back or re-extract if not directly in edited_df
+    temp_callsign_details = callsign_registration_lookup_df[["callsign", "callsign_group", "vehicle_type"]].drop_duplicates(subset=['callsign'])
+    full_rota_df = pd.merge(full_rota_df, temp_callsign_details, on="callsign", how="left", suffixes=('', '_lookup'))
+
+    # Prioritize columns from the merge if they existed, otherwise keep original (e.g. vehicle_type might be car/helicopter)
+    if 'vehicle_type_lookup' in full_rota_df.columns:
+        full_rota_df['vehicle_type'] = full_rota_df['vehicle_type_lookup']
+        full_rota_df.drop(columns=['vehicle_type_lookup'], inplace=True)
+    if 'callsign_group_lookup' in full_rota_df.columns:
+         full_rota_df['callsign_group'] = full_rota_df['callsign_group_lookup']
+         full_rota_df.drop(columns=['callsign_group_lookup'], inplace=True)
+
+
+    # Ensure consistent column order and only include columns present in the default rota file
+    # This also handles if edited_df accidentally gained/lost columns vs the default schema
+    final_columns = [col for col in df_default_rota.columns if col in full_rota_df.columns]
+    missing_cols = [col for col in df_default_rota.columns if col not in final_columns]
+    for col in missing_cols: # Add any missing columns with NaN, so structure matches
+        full_rota_df[col] = pd.NA
+
     full_rota_df = full_rota_df[df_default_rota.columns]
+
     st.dataframe(full_rota_df, hide_index=True)
     full_rota_df.to_csv('actual_data/HEMS_ROTA.csv', index=False)
-    st.write("Final rota automatically saved!")
+    st.success("Final rota automatically saved!")
 
 rota_setup()
 

--- a/class_hems_availability.py
+++ b/class_hems_availability.py
@@ -98,14 +98,14 @@ class HEMSAvailability():
         # Daily servicing check (in case sim starts during a service)
         [dow, hod, weekday, month, qtr, current_dt] = self.utilityClass.date_time_of_call(self.sim_start_date, self.env.now)
 
-        self.daily_servicing_check(current_dt, hod, qtr)
+        self.daily_servicing_check(current_dt, hod, month)
 
     def debug(self, message: str):
         if self.print_debug_messages:
             logging.debug(message)
             #print(message)
 
-    def daily_servicing_check(self, current_dt: datetime, hour: int, qtr: int):
+    def daily_servicing_check(self, current_dt: datetime, hour: int, month: int):
         """
             Function to iterate through the store and trigger the service check
             function in the HEMS class
@@ -167,13 +167,13 @@ class HEMSAvailability():
             self.debug(f"HEMS [{h.category} / {h.registration}] moved to service store")
             self.debug("***********")
 
-        self.debug(self.current_store_status(hour, qtr))
-        self.debug(self.current_store_status(hour, qtr, 'service'))
+        self.debug(self.current_store_status(hour, month))
+        self.debug(self.current_store_status(hour, month, 'service'))
 
         [dow, hod, weekday, month, qtr, current_dt] = self.utilityClass.date_time_of_call(self.sim_start_date, self.env.now)
         for h in self.store.items:
             if h.registration == 'g-daan':
-                self.debug(f"[{self.env.now}] g-daan status: in_use={h.in_use}, callsign={h.callsign}, group={h.callsign_group}, on_shift={h.hems_resource_on_shift(hod, qtr)}")
+                self.debug(f"[{self.env.now}] g-daan status: in_use={h.in_use}, callsign={h.callsign}, group={h.callsign_group}, on_shift={h.hems_resource_on_shift(hod, month)}")
 
         self.debug('------ END OF DAILY SERVICING CHECK -------')
 
@@ -336,7 +336,7 @@ class HEMSAvailability():
     def resource_allocation_lookup(self, reason: ResourceAllocationReason) -> str:
         return self.LOOKUP_LIST[reason.value]
 
-    def current_store_status(self, hour, qtr, store = 'resource') -> list[str]:
+    def current_store_status(self, hour, month, store = 'resource') -> list[str]:
             """
                 Debugging function to return current state of store
             """
@@ -347,10 +347,10 @@ class HEMSAvailability():
 
             if store == 'resource':
                 for h in self.store.items:
-                    current_store_items.append(f"{h.callsign} ({h.category} online: {h.hems_resource_on_shift(hour, qtr)} {h.registration})")
+                    current_store_items.append(f"{h.callsign} ({h.category} online: {h.hems_resource_on_shift(hour, month)} {h.registration})")
             else:
                 for h in self.serviceStore.items:
-                    current_store_items.append(f"{h.callsign} ({h.category} online: {h.hems_resource_on_shift(hour, qtr)} {h.registration})")
+                    current_store_items.append(f"{h.callsign} ({h.category} online: {h.hems_resource_on_shift(hour, month)} {h.registration})")
 
             return current_store_items
 
@@ -474,7 +474,7 @@ class HEMSAvailability():
             if (
                 h.in_use or  # Already dispatched
                 h.being_serviced or # Currently under maintenance
-                not h.hems_resource_on_shift(pt.hour, pt.qtr) or # Not scheduled for shift now
+                not h.hems_resource_on_shift(pt.hour, pt.month) or # Not scheduled for shift now
                 h.callsign_group in self.active_callsign_groups or # Another unit from this group is active (so crew is engaged elsewhere)
                 h.registration in self.active_registrations # This specific unit is already dispatched
             ):
@@ -589,7 +589,7 @@ class HEMSAvailability():
                         r != primary and
                         r.callsign_group == pt.hems_callsign_group and
                         r.category == pt.hems_category and
-                        r.hems_resource_on_shift(pt.hour, pt.qtr) and
+                        r.hems_resource_on_shift(pt.hour, pt.month) and
                         r.callsign_group not in self.active_callsign_groups and
                         r.registration not in self.active_registrations and
                         r.callsign not in self.active_callsigns
@@ -803,7 +803,7 @@ class HEMSAvailability():
             if (
                 h.in_use or # Already dispatched
                 h.being_serviced or # Currently under maintenance
-                not h.hems_resource_on_shift(pt.hour, pt.qtr) or # Not scheduled for shift now
+                not h.hems_resource_on_shift(pt.hour, pt.month) or # Not scheduled for shift now
                 h.callsign_group in self.active_callsign_groups or  # Another unit from this group is active (so crew is engaged elsewhere)
                 h.registration in self.active_registrations # This specific unit is already dispatched
             ):
@@ -921,7 +921,7 @@ class HEMSAvailability():
                         r != primary and
                         r.callsign_group == pt.hems_callsign_group and
                         r.category == pt.hems_category and
-                        r.hems_resource_on_shift(pt.hour, pt.qtr) and
+                        r.hems_resource_on_shift(pt.hour, pt.month) and
                         r.callsign_group not in self.active_callsign_groups and
                         r.registration not in self.active_registrations and
                         r.callsign not in self.active_callsigns

--- a/des_hems.py
+++ b/des_hems.py
@@ -222,7 +222,7 @@ class DES_HEMS:
                 #self.debug(ia_dict)
 
                 # Also run scripts to check HEMS resources to see whether they are starting/finishing service
-                yield self.env.process(self.hems_resources.daily_servicing_check(current_dt, hod, qtr))
+                yield self.env.process(self.hems_resources.daily_servicing_check(current_dt, hod, month))
 
 
             if self.calls_today > 0:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     calls: Tests relating to the number of calls/jobs generated
     jobdurations: Tests relating to the duration of jobs
     quick: Tests to quickly check the sim is functioning at a basic level
+    medium: Tests to quickly check the sim runs over a longer period of time than in the quick test
     reproducibility: Tests to check that random seeds behave as expected
     performance: Tests to check that basic metrics behave as expected when core parameters change
     callsign: Tests relating to correct allocation of callsigns

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ pytz==2024.1
 simpy==4.1.1
 six==1.16.0
 tzdata==2024.1
-plotly==5.23.0
-streamlit==1.42.0
+plotly==6.0.1
+streamlit==1.45.1
 sim-tools==0.6.1
 vidigi==0.0.3
 joblib==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ simpy==4.1.1
 six==1.16.0
 tzdata==2024.1
 plotly==5.23.0
-streamlit==1.45.1
+streamlit==1.42.0
 sim-tools==0.6.1
 vidigi==0.0.3
 joblib==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ simpy==4.1.1
 six==1.16.0
 tzdata==2024.1
 plotly==5.23.0
-streamlit==1.42.0
+streamlit==1.45.1
 sim-tools==0.6.1
 vidigi==0.0.3
 joblib==1.4.2

--- a/tests/test_unittest_model.py
+++ b/tests/test_unittest_model.py
@@ -94,12 +94,39 @@ def test_model_runs():
 
       collateRunResults()
 
-      save_logs("test_model_runs.txt")
+      save_logs("test_model_runs_5_weeks.txt")
 
       # Read simulation results
       results_df = pd.read_csv("data/run_results.csv")
 
-      assert len(results_df) > 5, "[FAIL - BASIC FUNCTIONS] Model failed to run"
+      assert len(results_df) > 5, "[FAIL - BASIC FUNCTIONS] Model failed to run for a period of 5 weeks"
+
+   finally:
+      del results_df
+      gc.collect()
+
+@pytest.mark.medium
+def test_model_runs_more():
+   try:
+      removeExistingResults(remove_run_results_csv=True)
+
+      parallelProcessJoblib(
+         total_runs=1,
+         sim_duration=60 * 24 * 7 * 52 * 2, # Run for two years
+         warm_up_time=0,
+         sim_start_date=datetime.strptime("2023-01-01 05:00:00", "%Y-%m-%d %H:%M:%S"),
+         amb_data=False,
+         print_debug_messages=True
+         )
+
+      collateRunResults()
+
+      save_logs("test_model_runs_2_years.txt")
+
+      # Read simulation results
+      results_df = pd.read_csv("data/run_results.csv")
+
+      assert len(results_df) > 5, "[FAIL - BASIC FUNCTIONS] Model failed to run for a period of 2 years"
 
    finally:
       del results_df

--- a/visualisation/_utilisation_result_calculation.py
+++ b/visualisation/_utilisation_result_calculation.py
@@ -838,13 +838,17 @@ def create_UTIL_rwc_plot(call_df,
 
     fig.update_layout(
         xaxis=dict(
-            titlefont = dict(size=20),
+            title = dict(font=dict(size=20)),
             tickfont = dict(size=25),
             tickmode='array',
             tickvals=tick_vals,  # Ensure ticks are at integer positions
             range=[min_x - 0.5, max_x + 0.5]  # Extend range to start 0.5 units earlier
         ),
-        yaxis=dict(ticksuffix="%", titlefont = dict(size = 15), tickfont = dict(size=20),
+        yaxis=dict(
+            ticksuffix="%",
+            title = dict(
+                dict(font=dict(size=15))),
+                   tickfont = dict(size=20),
                      range=[0, 100]),
 
         legend = dict(font = dict(size = 15)),


### PR DESCRIPTION
This completely rewrites how rotas are handled in the frontend so that the required scenarios can be supported.

- Vehicles are now handled separately from their rotas (so that adding/removing vehicles is not confused by the fact that each vehicle's rota can have multiple entries to handle different ec/cc times. 
- Rotas for critical care cars that are in a callsign group with a helicopter will default to being the same as the associated helicopter, but can optionally be overriden
- The definition of 'summer' and 'winter' now use months instead of quarters, and the start/end months can now be edited via the user interface

Other changes:
- added additional test that runs for longer (runnable via `pytest -m medium`) as the quick text doesn't pick up bugs that only kick in at different points in the year (as quick test only runs for 5 weeks to check model is functioning at a very basic level). 
- added additional detail to the cc/ec missed jobs summary on the key metrics page so that it's easier to quickly get a sense of how this run compares to the historical data.

Package version changes:
- requirements.txt bumps streamlit and plotly versions to 1.45.1 and 6.0.1 respectively. 
